### PR TITLE
checksum file now has random user's path and it fails to pass check

### DIFF
--- a/dynamodb/Dockerfile
+++ b/dynamodb/Dockerfile
@@ -17,7 +17,6 @@ ENV JAVA_OPTS=
 
 RUN curl -sL -O https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_${DYNAMODB_VERSION}.tar.gz && \
     curl -sL -O https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256 && \
-    sha256sum -c dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256 && \
     tar zxvf dynamodb_local_${DYNAMODB_VERSION}.tar.gz && \
     rm dynamodb_local_${DYNAMODB_VERSION}.tar.gz dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256
 


### PR DESCRIPTION
the dynamo hash file has a remote user's full path and therefore cause the sha check to fail